### PR TITLE
Subscribe to channel with subscribe_to helper, fixes #23

### DIFF
--- a/lib/danthes/view_helpers.rb
+++ b/lib/danthes/view_helpers.rb
@@ -15,7 +15,7 @@ module Danthes
     def subscribe_to(channel, opts = {})
       js_tag = opts.delete(:include_js_tag){ true }
       subscription = Danthes.subscription(channel: channel)
-      content = raw("if (typeof Danthes != 'undefined') { Danthes.sign(#{subscription.to_json}) }")
+      content = raw("if (typeof Danthes != 'undefined') { Danthes.sign(#{subscription.to_json}); Danthes.subscribe('#{channel}'); }")
       js_tag ? content_tag('script', content, type: 'text/javascript') : content
     end
   end


### PR DESCRIPTION
The documentation is wrong. The `subscribe_to` helper currently **does not** subscribe the user to a the channel.

This PR adds a call to `Danthes.subscribe` in the `subscribe_to` helper to subscribe to the channel. Fixes issue #23 
